### PR TITLE
Close i2c for #5

### DIFF
--- a/library/sgp30/__init__.py
+++ b/library/sgp30/__init__.py
@@ -173,3 +173,6 @@ class SGP30:
 
     def set_baseline(self, eco2, tvoc):
         self.command('set_baseline', eco2, tvoc)
+
+    def __del__(self):
+        self._i2c_dev.close()

--- a/library/tests/test_setup.py
+++ b/library/tests/test_setup.py
@@ -3,8 +3,11 @@ from tools import MockI2CDev, MockI2CMsg
 
 def test_setup():
     from sgp30 import SGP30
-    sgp30 = SGP30(i2c_dev=MockI2CDev(), i2c_msg=MockI2CMsg())
+    dev = MockI2CDev()
+    assert dev._open is True
+    sgp30 = SGP30(i2c_dev=dev, i2c_msg=MockI2CMsg())
     del sgp30
+    assert dev._open is False
 
 
 def test_get_unique_id():

--- a/library/tests/tools.py
+++ b/library/tests/tools.py
@@ -3,6 +3,7 @@ import struct
 
 class MockI2CDev():
     def __init__(self):
+        self._open = True
         self._last_write = None
 
     def i2c_rdwr(self, a, b=None):
@@ -12,6 +13,9 @@ class MockI2CDev():
             a.process(self._last_write)
         if b is not None:
             b.process(self._last_write)
+
+    def close(self):
+        self._open = False
 
 
 class MockI2CMsg():
@@ -44,7 +48,6 @@ class MockI2CMsgR():
             buf.append(self.calculate_crc(word))
 
         self.buf = bytearray(buf)
-
 
     def calculate_crc(self, data):
         """Calculate an 8-bit CRC from a 16-bit word

--- a/library/tox.ini
+++ b/library/tox.ini
@@ -14,7 +14,7 @@ deps =
 
 [testenv:qa]
 commands =
-	check-manifest --ignore tox.ini,tests*,.coveragerc
+	check-manifest --ignore tox.ini,tests/*,.coveragerc
 	python setup.py check -m -r -s
 	flake8 --ignore E501
 deps =


### PR DESCRIPTION
Closes the i2c on `__exit__` to avoid leaving multiple file handles open when the library is re-used in a single, persistent Python thread.