### PR TITLE
Fix set_baseline method in class SGP30

### DIFF
--- a/library/sgp30/__init__.py
+++ b/library/sgp30/__init__.py
@@ -172,4 +172,4 @@ class SGP30:
         return SGP30Reading(eco2, tvoc)
 
     def set_baseline(self, eco2, tvoc):
-        self.command('set_baseline', tvoc, eco2)
+        self.command('set_baseline', [tvoc, eco2])

--- a/library/sgp30/__init__.py
+++ b/library/sgp30/__init__.py
@@ -172,4 +172,4 @@ class SGP30:
         return SGP30Reading(eco2, tvoc)
 
     def set_baseline(self, eco2, tvoc):
-        self.command('set_baseline', eco2, tvoc)
+        self.command('set_baseline', tvoc, eco2)


### PR DESCRIPTION
As explained in this [comment](https://github.com/pimoroni/sgp30-python/issues/4#issuecomment-713835433) the _set_baseline_ method of the _SGP30_ class has the wrong parameter order, and is also making an incorrect call to self.command.

In this pull request these issues are fixed and the _set_baseline_ method can now be used to correctly set a new baseline.

With the following example it now works as expected with this change:
```
from sgp30 import SGP30
sgp30 = SGP30()

result = sgp30.get_baseline()
print("{:02x} {:02x}".format(result.equivalent_co2, result.total_voc))
sgp30.set_baseline(result.equivalent_co2, result.total_voc)
result = sgp30.get_baseline()
print("{:02x} {:02x}".format(result.equivalent_co2, result.total_voc))
```

=>

```
90d7 936b
90d7 936b
```